### PR TITLE
Add staged local transcription pipeline

### DIFF
--- a/asr/transcriber.py
+++ b/asr/transcriber.py
@@ -1,0 +1,139 @@
+"""ASR transcription utilities with VRAM-aware loading."""
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+from utils.memory import VRAMLimitedModel, free_cuda, try_gpu_then_cpu
+
+try:  # pragma: no cover - optional dependency during tests
+    from faster_whisper import WhisperModel
+except ImportError:  # pragma: no cover
+    WhisperModel = None  # type: ignore
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class ASRConfig:
+    model: str
+    device: str = "cuda"
+    compute_type: str = "float16"
+    max_parallel: int = 1
+    vad: Optional[str] = None
+    gpu_memory_limit: Optional[int] = None
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "ASRConfig":
+        return cls(
+            model=data.get("model") or data.get("name") or data.get("path") or "small",
+            device=data.get("device", "cuda"),
+            compute_type=data.get("compute_type", "float16"),
+            max_parallel=int(data.get("max_parallel", 1)),
+            vad=data.get("vad"),
+            gpu_memory_limit=data.get("gpu_memory_limit") or data.get("gpu_memory") or int(7 * 1024),
+        )
+
+
+class ASRTranscriber:
+    """ASR pipeline that loads whisper checkpoints lazily."""
+
+    def __init__(self, config: Dict[str, Any], *, allow_remote: bool = False) -> None:
+        self.config = ASRConfig.from_dict(config)
+        self.allow_remote = allow_remote
+        if WhisperModel is None:
+            raise RuntimeError("faster-whisper is not installed")
+        self._model_ctx: Optional[VRAMLimitedModel] = None
+        self._model: Optional[WhisperModel] = None  # type: ignore[name-defined]
+        self._current_device: Optional[str] = None
+
+    def __enter__(self) -> "ASRTranscriber":
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:
+        self._release_model()
+        return False
+
+    # Public API -----------------------------------------------------------------
+    def transcribe(self, media_path: Path, output_path: Path) -> None:
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+
+        def run_on_gpu() -> None:
+            if self.config.device == "cpu":
+                return run_on_cpu()
+            model = self._ensure_model("cuda")
+            self._transcribe_with_model(model, media_path, output_path)
+
+        def run_on_cpu() -> None:
+            model = self._ensure_model("cpu")
+            self._transcribe_with_model(model, media_path, output_path)
+
+        try_gpu_then_cpu(run_on_gpu, on_cpu=run_on_cpu if self.config.device != "cpu" else None)
+
+    # Internal helpers ------------------------------------------------------------
+    def _transcribe_with_model(
+        self,
+        model: "WhisperModel",
+        media_path: Path,
+        output_path: Path,
+    ) -> None:
+        segments, info = model.transcribe(
+            str(media_path),
+            beam_size=1,
+            vad_filter=self.config.vad == "silero",
+        )
+        logger.info(
+            "Transcribed %s (language=%s, duration=%.2fs)",
+            media_path.name,
+            getattr(info, "language", "unknown"),
+            getattr(info, "duration", 0.0),
+        )
+        with output_path.open("w", encoding="utf-8") as f:
+            for seg in segments:
+                payload = {
+                    "start": getattr(seg, "start", 0.0),
+                    "end": getattr(seg, "end", 0.0),
+                    "text": getattr(seg, "text", ""),
+                }
+                f.write(json.dumps(payload, ensure_ascii=False) + "\n")
+
+    def _ensure_model(self, device: str) -> "WhisperModel":
+        if self._model is not None and self._current_device == device:
+            return self._model
+        self._release_model()
+        self._current_device = device
+        gpu_limit = self.config.gpu_memory_limit
+        if device == "cpu":
+            gpu_limit = None
+        logger.debug("Loading ASR model on %s with limit=%s", device, gpu_limit)
+
+        def load() -> "WhisperModel":
+            return WhisperModel(  # type: ignore[call-arg]
+                self.config.model,
+                device=device,
+                compute_type=self.config.compute_type,
+                local_files_only=not self.allow_remote,
+                gpu_memory_limit=gpu_limit,
+            )
+
+        self._model_ctx = VRAMLimitedModel(load, self._unload_model)
+        self._model = self._model_ctx.__enter__()
+        return self._model
+
+    def _release_model(self) -> None:
+        if self._model_ctx is not None:
+            self._model_ctx.__exit__(None, None, None)
+        self._model_ctx = None
+        self._model = None
+        self._current_device = None
+        free_cuda()
+
+    @staticmethod
+    def _unload_model(model: "WhisperModel") -> None:  # pragma: no cover - library handles cleanup
+        try:
+            model = None
+        finally:
+            free_cuda()

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -1,0 +1,22 @@
+asr:
+  engine: faster-whisper
+  model: small
+  device: cuda
+  compute_type: float16
+  max_parallel: 1
+  vad: silero
+  gpu_memory_limit: 7168
+llm:
+  backend: llm
+  model_path: ./models/llm/qwen2.5-7b-instruct-q4.gguf
+  quant: q4
+  max_input_len: 4096
+  batch_size: 4
+  max_parallel: 1
+pipeline:
+  temp_dir: ./interim
+  output_dir: ./output
+  stages: [A, B, C]
+runtime:
+  allow_remote: false
+  log_level: INFO

--- a/nlp/local_corrector.py
+++ b/nlp/local_corrector.py
@@ -1,0 +1,163 @@
+"""Local text correction utilities supporting LLM and rule-based backends."""
+from __future__ import annotations
+
+import logging
+import re
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Optional
+
+from utils.memory import VRAMLimitedModel, free_cuda, try_gpu_then_cpu
+
+logger = logging.getLogger(__name__)
+
+try:  # pragma: no cover - optional heavy dependency
+    from llama_cpp import Llama
+except ImportError:  # pragma: no cover
+    Llama = None  # type: ignore
+
+
+class LocalTextCorrector:
+    """Lazy-loading corrector that supports LLM and rule-based strategies."""
+
+    def __init__(self, config: Dict[str, Any], *, allow_remote: bool = False) -> None:
+        self.config = config
+        self.allow_remote = allow_remote
+        self.backend = config.get("backend", "rules").lower()
+        self.model_path = config.get("model_path")
+        self.quant = config.get("quant")
+        self.max_input_len = int(config.get("max_input_len", 4096))
+        self.batch_size = int(config.get("batch_size", config.get("max_batch", 4)))
+        self._model_ctx: Optional[VRAMLimitedModel] = None
+        self._model = None
+        self._device: Optional[str] = None
+
+    # ------------------------------------------------------------------
+    def __enter__(self) -> "LocalTextCorrector":
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:
+        self._release_model()
+        return False
+
+    # ------------------------------------------------------------------
+    def correct_batch(self, texts: Iterable[str]) -> List[str]:
+        batch = list(texts)
+        if not batch:
+            return []
+        if self.backend in {"rules", "rule", "regex"}:
+            return [self._rule_based_normalize(text) for text in batch]
+        if self.backend in {"llm", "llama", "instructional"}:
+            return self._llm_correct(batch)
+        raise ValueError(f"Unsupported backend: {self.backend}")
+
+    def correct(self, text: str) -> str:
+        return self.correct_batch([text])[0]
+
+    # LLM backend -------------------------------------------------------
+    def _llm_correct(self, batch: List[str]) -> List[str]:
+        if Llama is None:
+            raise RuntimeError("llama-cpp-python is required for LLM backend")
+
+        def run_on_gpu() -> List[str]:
+            device = "cuda"
+            if not self._gpu_available():
+                return run_on_cpu()
+            model = self._ensure_llm(device)
+            return [self._run_prompt(model, item) for item in batch]
+
+        def run_on_cpu() -> List[str]:
+            model = self._ensure_llm("cpu")
+            return [self._run_prompt(model, item) for item in batch]
+
+        return try_gpu_then_cpu(run_on_gpu, on_cpu=run_on_cpu)
+
+    def _run_prompt(self, model: Any, text: str) -> str:
+        prompt = self._build_prompt(text)
+        result = model(
+            prompt,
+            max_tokens=self.max_input_len,
+            temperature=0.0,
+            top_p=0.95,
+        )
+        choices = result.get("choices", [])
+        if not choices:
+            return text
+        output = choices[0].get("text", "").strip()
+        return output or text
+
+    def _build_prompt(self, text: str) -> str:
+        system_prompt = self.config.get(
+            "system_prompt",
+            "You are a transcription editor. Fix punctuation, casing, and typos while preserving meaning.",
+        )
+        return f"<|system|>\n{system_prompt}\n<|user|>\n{text.strip()}\n<|assistant|>"
+
+    def _ensure_llm(self, device: str) -> Any:
+        if self._model is not None and self._device == device:
+            return self._model
+        self._release_model()
+        logger.debug("Loading LLM corrector on %s", device)
+
+        def load() -> Any:
+            params = {
+                "model_path": self._resolve_model_path(),
+                "n_ctx": self.max_input_len,
+                "n_gpu_layers": -1 if device != "cpu" else 0,
+                "seed": 0,
+                "chat_format": self.config.get("chat_format", "chatml"),
+            }
+            if device == "cpu":
+                params["n_gpu_layers"] = 0
+            return Llama(**params)
+
+        self._model_ctx = VRAMLimitedModel(load, self._unload_model)
+        self._model = self._model_ctx.__enter__()
+        self._device = device
+        return self._model
+
+    def _release_model(self) -> None:
+        if self._model_ctx is not None:
+            self._model_ctx.__exit__(None, None, None)
+        self._model_ctx = None
+        self._model = None
+        self._device = None
+        free_cuda()
+
+    def _resolve_model_path(self) -> str:
+        if not self.model_path:
+            raise ValueError("llm.model_path must be specified for LLM backend")
+        return str(Path(self.model_path).expanduser())
+
+    @staticmethod
+    def _gpu_available() -> bool:
+        try:
+            import torch  # type: ignore
+
+            return torch.cuda.is_available()
+        except Exception:  # pragma: no cover - torch may not be installed
+            return False
+
+    @staticmethod
+    def _unload_model(model: Any) -> None:  # pragma: no cover - library handles cleanup
+        del model
+        free_cuda()
+
+    # Rule backend ------------------------------------------------------
+    _whitespace_re = re.compile(r"\s+")
+    _punctuation_replacements = {
+        r" ?!": "!",
+        r" ?,": ",",
+        r" ?\.": ".",
+    }
+
+    def _rule_based_normalize(self, text: str) -> str:
+        original = text
+        text = text.strip()
+        text = self._whitespace_re.sub(" ", text)
+        for pattern, replacement in self._punctuation_replacements.items():
+            text = re.sub(pattern, replacement, text)
+        text = re.sub(r"\s+([,.!?])", r"\1", text)
+        text = re.sub(r"([!?]){2,}", r"\1", text)
+        text = text[: self.max_input_len]
+        logger.debug("Rule-based normalization: '%s' -> '%s'", original, text)
+        return text

--- a/pipeline/scheduler.py
+++ b/pipeline/scheduler.py
@@ -1,0 +1,161 @@
+"""Pipeline scheduler orchestrating staged processing."""
+from __future__ import annotations
+
+import json
+import logging
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+from typing import Any, Dict, List, Sequence
+
+from asr.transcriber import ASRTranscriber
+from nlp.local_corrector import LocalTextCorrector
+from utils.memory import free_cuda
+
+logger = logging.getLogger(__name__)
+
+
+class PipelineScheduler:
+    def __init__(
+        self,
+        config: Dict[str, Any],
+        *,
+        asr_cls=ASRTranscriber,
+        corrector_cls=LocalTextCorrector,
+    ) -> None:
+        self.config = config
+        self.asr_cls = asr_cls
+        self.corrector_cls = corrector_cls
+        self.pipeline_cfg = config.get("pipeline", {})
+        self.asr_cfg = config.get("asr", {})
+        self.llm_cfg = config.get("llm", {})
+        runtime_cfg = config.get("runtime", {})
+        self.allow_remote = bool(runtime_cfg.get("allow_remote", False))
+        self.temp_dir = Path(self.pipeline_cfg.get("temp_dir", "./interim"))
+        self.output_dir = Path(self.pipeline_cfg.get("output_dir", "./output"))
+        self.output_dir.mkdir(parents=True, exist_ok=True)
+        self.temp_dir.mkdir(parents=True, exist_ok=True)
+
+    # ------------------------------------------------------------------
+    def run_stage(self, stage: str, inputs: Path) -> None:
+        stage = stage.upper()
+        if stage == "A":
+            self._run_stage_a(inputs)
+        elif stage == "B":
+            self._run_stage_b(inputs)
+        elif stage == "C":
+            self._run_stage_c(inputs)
+        else:
+            raise ValueError(f"Unsupported stage {stage}")
+        free_cuda()
+
+    def run_all(self, inputs: Path) -> None:
+        self.run_stage("A", inputs)
+        raw_dir = self.temp_dir
+        self.run_stage("B", raw_dir)
+        self.run_stage("C", raw_dir)
+
+    # Stage A -----------------------------------------------------------
+    def _run_stage_a(self, inputs: Path) -> None:
+        videos = self._list_media_files(inputs)
+        if not videos:
+            logger.warning("Stage A: no input videos in %s", inputs)
+            return
+        max_workers = int(self.asr_cfg.get("max_parallel", 1))
+        if self.asr_cfg.get("device", "cuda") == "cuda":
+            max_workers = min(max_workers, 1)
+        logger.info("Stage A: transcribing %d files", len(videos))
+
+        def worker(video_path: Path) -> None:
+            target = self.temp_dir / f"{video_path.stem}.raw.jsonl"
+            with self.asr_cls(self.asr_cfg, allow_remote=self.allow_remote) as transcriber:
+                transcriber.transcribe(video_path, target)
+
+        with ThreadPoolExecutor(max_workers=max_workers) as executor:
+            list(executor.map(worker, videos))
+        free_cuda()
+
+    # Stage B -----------------------------------------------------------
+    def _run_stage_b(self, inputs: Path) -> None:
+        raw_files = sorted(inputs.glob("*.raw.jsonl"))
+        if not raw_files:
+            logger.warning("Stage B: no raw transcripts in %s", inputs)
+            return
+        max_workers = int(self.llm_cfg.get("max_parallel", 1))
+        if self.llm_cfg.get("backend", "rules") != "rules":
+            max_workers = min(max_workers, 1)
+        logger.info("Stage B: correcting %d transcripts", len(raw_files))
+
+        def worker(raw_path: Path) -> None:
+            clean_name = raw_path.stem.replace(".raw", "") + ".clean.jsonl"
+            clean_path = raw_path.with_name(clean_name)
+            segments = self._load_segments(raw_path)
+            batch_size = max(1, int(self.llm_cfg.get("batch_size", self.llm_cfg.get("max_batch", 4))))
+            with self.corrector_cls(self.llm_cfg, allow_remote=self.allow_remote) as corrector:
+                corrected_segments: List[Dict[str, Any]] = []
+                for i in range(0, len(segments), batch_size):
+                    batch = [seg["text"] for seg in segments[i : i + batch_size]]
+                    corrected_texts = corrector.correct_batch(batch)
+                    for seg, new_text in zip(segments[i : i + batch_size], corrected_texts):
+                        corrected_segments.append({**seg, "text": new_text})
+            self._write_segments(clean_path, corrected_segments)
+
+        with ThreadPoolExecutor(max_workers=max_workers) as executor:
+            list(executor.map(worker, raw_files))
+        free_cuda()
+
+    # Stage C -----------------------------------------------------------
+    def _run_stage_c(self, inputs: Path) -> None:
+        clean_files = sorted(inputs.glob("*.clean.jsonl"))
+        if not clean_files:
+            logger.warning("Stage C: no cleaned transcripts in %s", inputs)
+            return
+        logger.info("Stage C: exporting %d transcripts", len(clean_files))
+        for path in clean_files:
+            segments = self._load_segments(path)
+            self._export_to_txt(path.stem.replace(".clean", ""), segments)
+            self._export_to_srt(path.stem.replace(".clean", ""), segments)
+        free_cuda()
+
+    # Helpers -----------------------------------------------------------
+    def _list_media_files(self, directory: Path) -> List[Path]:
+        extensions = {".mp3", ".wav", ".mp4", ".mkv", ".mov", ".flac"}
+        return [p for p in sorted(directory.iterdir()) if p.suffix.lower() in extensions]
+
+    @staticmethod
+    def _load_segments(path: Path) -> List[Dict[str, Any]]:
+        segments: List[Dict[str, Any]] = []
+        with path.open("r", encoding="utf-8") as f:
+            for line in f:
+                if line.strip():
+                    segments.append(json.loads(line))
+        return segments
+
+    @staticmethod
+    def _write_segments(path: Path, segments: Sequence[Dict[str, Any]]) -> None:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        with path.open("w", encoding="utf-8") as f:
+            for seg in segments:
+                f.write(json.dumps(seg, ensure_ascii=False) + "\n")
+
+    def _export_to_txt(self, base_name: str, segments: Sequence[Dict[str, Any]]) -> None:
+        text = " ".join(seg.get("text", "") for seg in segments)
+        target = self.output_dir / f"{base_name}.txt"
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(text.strip() + "\n", encoding="utf-8")
+
+    def _export_to_srt(self, base_name: str, segments: Sequence[Dict[str, Any]]) -> None:
+        target = self.output_dir / f"{base_name}.srt"
+        target.parent.mkdir(parents=True, exist_ok=True)
+        with target.open("w", encoding="utf-8") as f:
+            for idx, seg in enumerate(segments, start=1):
+                start = self._format_timestamp(seg.get("start", 0.0))
+                end = self._format_timestamp(seg.get("end", 0.0))
+                f.write(f"{idx}\n{start} --> {end}\n{seg.get('text', '').strip()}\n\n")
+
+    @staticmethod
+    def _format_timestamp(seconds: float) -> str:
+        ms = int(round(seconds * 1000))
+        hours, rem = divmod(ms, 3600_000)
+        minutes, rem = divmod(rem, 60_000)
+        secs, ms = divmod(rem, 1000)
+        return f"{hours:02d}:{minutes:02d}:{secs:02d},{ms:03d}"

--- a/run.py
+++ b/run.py
@@ -1,0 +1,60 @@
+"""CLI entrypoint for staged transcription pipeline."""
+from __future__ import annotations
+
+import argparse
+import logging
+from pathlib import Path
+from typing import Any, Dict
+
+import yaml
+
+from pipeline.scheduler import PipelineScheduler
+
+
+def load_config(path: Path) -> Dict[str, Any]:
+    with path.open("r", encoding="utf-8") as f:
+        return yaml.safe_load(f) or {}
+
+
+def configure_logging(level: str) -> None:
+    logging.basicConfig(
+        level=getattr(logging, level.upper(), logging.INFO),
+        format="%(asctime)s | %(levelname)s | %(name)s | %(message)s",
+    )
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Audio/Video transcription pipeline")
+    parser.add_argument("command", choices=["stage-a", "stage-b", "stage-c", "all"], help="Stage to run")
+    parser.add_argument("--inputs", required=True, help="Path to input directory")
+    parser.add_argument("--config", default="config.yaml", help="Path to YAML config")
+    parser.add_argument("--log-level", default=None, help="Logging level override")
+    return parser
+
+
+def main(argv: Any = None) -> None:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    config_path = Path(args.config)
+    config = load_config(config_path)
+    log_level = args.log_level or config.get("runtime", {}).get("log_level", "INFO")
+    configure_logging(log_level)
+    scheduler = PipelineScheduler(config)
+    inputs = Path(args.inputs)
+    inputs.mkdir(parents=True, exist_ok=True)
+
+    command = args.command
+    if command == "stage-a":
+        scheduler.run_stage("A", inputs)
+    elif command == "stage-b":
+        scheduler.run_stage("B", inputs)
+    elif command == "stage-c":
+        scheduler.run_stage("C", inputs)
+    elif command == "all":
+        scheduler.run_all(inputs)
+    else:  # pragma: no cover - argparse restricts commands
+        raise ValueError(f"Unknown command {command}")
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,6 @@
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))

--- a/tests/test_local_corrector.py
+++ b/tests/test_local_corrector.py
@@ -1,0 +1,10 @@
+from nlp.local_corrector import LocalTextCorrector
+
+
+def test_rule_based_deterministic_normalization():
+    config = {"backend": "rules", "max_input_len": 128}
+    with LocalTextCorrector(config) as corrector:
+        text = "  Hello ,  world !!  "
+        result1 = corrector.correct(text)
+        result2 = corrector.correct(text)
+    assert result1 == result2 == "Hello, world!"

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -1,0 +1,28 @@
+import pytest
+
+from utils.memory import try_gpu_then_cpu
+
+
+def test_try_gpu_then_cpu_fallback():
+    attempts = {"gpu": 0, "cpu": 0}
+
+    def gpu_fn():
+        attempts["gpu"] += 1
+        raise RuntimeError("CUDA out of memory")
+
+    def cpu_fn():
+        attempts["cpu"] += 1
+        return "cpu-result"
+
+    result = try_gpu_then_cpu(gpu_fn, on_cpu=cpu_fn)
+    assert result == "cpu-result"
+    assert attempts["gpu"] == 1
+    assert attempts["cpu"] == 1
+
+
+def test_try_gpu_then_cpu_no_retry_on_non_oom():
+    def gpu_fn():
+        raise RuntimeError("some other error")
+
+    with pytest.raises(RuntimeError):
+        try_gpu_then_cpu(gpu_fn, on_cpu=lambda: None)

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -1,0 +1,74 @@
+import json
+from pathlib import Path
+
+from pipeline.scheduler import PipelineScheduler
+
+
+class DummyTranscriber:
+    def __init__(self, config, allow_remote=False):
+        self.config = config
+        self.allow_remote = allow_remote
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+    def transcribe(self, media_path: Path, output_path: Path) -> None:
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        data = [
+            {"start": 0.0, "end": 1.0, "text": "hello"},
+            {"start": 1.0, "end": 2.0, "text": "world"},
+        ]
+        with output_path.open("w", encoding="utf-8") as f:
+            for row in data:
+                f.write(json.dumps(row) + "\n")
+
+
+class DummyCorrector:
+    def __init__(self, config, allow_remote=False):
+        self.config = config
+        self.allow_remote = allow_remote
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+    def correct_batch(self, texts):
+        return [text.upper() for text in texts]
+
+
+def test_pipeline_stage_sequence(tmp_path):
+    videos_dir = tmp_path / "videos"
+    videos_dir.mkdir()
+    (videos_dir / "sample.mp4").write_bytes(b"")
+
+    config = {
+        "asr": {"model": "dummy", "device": "cpu", "max_parallel": 1},
+        "llm": {"backend": "rules", "batch_size": 2},
+        "pipeline": {
+            "temp_dir": str(tmp_path / "interim"),
+            "output_dir": str(tmp_path / "output"),
+        },
+        "runtime": {"allow_remote": False},
+    }
+
+    scheduler = PipelineScheduler(config, asr_cls=DummyTranscriber, corrector_cls=DummyCorrector)
+    scheduler.run_all(videos_dir)
+
+    raw_path = tmp_path / "interim" / "sample.raw.jsonl"
+    clean_path = tmp_path / "interim" / "sample.clean.jsonl"
+    txt_path = tmp_path / "output" / "sample.txt"
+    srt_path = tmp_path / "output" / "sample.srt"
+
+    assert raw_path.exists()
+    assert clean_path.exists()
+    assert txt_path.exists()
+    assert srt_path.exists()
+
+    clean_lines = clean_path.read_text(encoding="utf-8").splitlines()
+    assert "HELLO" in clean_lines[0]
+    assert "WORLD" in clean_lines[1]

--- a/utils/memory.py
+++ b/utils/memory.py
@@ -1,0 +1,79 @@
+"""Utilities for managing GPU memory and OOM fallbacks."""
+from __future__ import annotations
+
+import contextlib
+import gc
+import logging
+from typing import Any, Callable, Optional
+
+logger = logging.getLogger(__name__)
+
+
+class VRAMLimitedModel(contextlib.AbstractContextManager):
+    """Context manager that loads a model lazily and frees GPU memory on exit."""
+
+    def __init__(
+        self,
+        load_fn: Callable[[], Any],
+        unload_fn: Optional[Callable[[Any], None]] = None,
+    ) -> None:
+        self._load_fn = load_fn
+        self._unload_fn = unload_fn
+        self.model: Any = None
+
+    def __enter__(self) -> Any:  # type: ignore[override]
+        logger.debug("Loading VRAM limited model via %s", self._load_fn)
+        self.model = self._load_fn()
+        return self.model
+
+    def __exit__(self, exc_type, exc, tb) -> None:  # type: ignore[override]
+        try:
+            if self._unload_fn and self.model is not None:
+                self._unload_fn(self.model)
+        finally:
+            self.model = None
+            free_cuda()
+        return False
+
+
+def _is_oom_error(exc: BaseException) -> bool:
+    message = str(exc).lower()
+    return "out of memory" in message or "cuda oom" in message or "cublas error" in message
+
+
+def try_gpu_then_cpu(
+    fn: Callable[[], Any],
+    *,
+    on_cpu: Optional[Callable[[], Any]] = None,
+    on_fail: Optional[Callable[[BaseException], None]] = None,
+) -> Any:
+    """Execute ``fn`` and retry on CPU if an OOM error is raised."""
+
+    try:
+        return fn()
+    except RuntimeError as exc:
+        if not _is_oom_error(exc) or on_cpu is None:
+            if on_fail:
+                on_fail(exc)
+            raise
+        logger.warning("OOM detected on GPU; retrying on CPU")
+        free_cuda()
+        return on_cpu()
+    except Exception as exc:  # pragma: no cover - unexpected errors
+        if on_fail:
+            on_fail(exc)
+        raise
+
+
+def free_cuda() -> None:
+    """Safely release GPU memory."""
+
+    try:
+        import torch  # type: ignore
+
+        if torch.cuda.is_available():
+            torch.cuda.empty_cache()
+    except Exception:  # pragma: no cover - torch may be missing
+        pass
+    finally:
+        gc.collect()


### PR DESCRIPTION
## Summary
- add VRAM-aware faster-whisper transcriber with automatic CPU fallback
- implement local text correction backends and staged pipeline scheduler with CLI integration
- provide memory utilities, sample config, and regression tests for fallback and orchestration

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68e3c0524448833384743cc4981c2f99